### PR TITLE
Storrington Mass Parts generation: Gospel Acclamation

### DIFF
--- a/insertWeeklySchedule.js
+++ b/insertWeeklySchedule.js
@@ -97,7 +97,6 @@ function _handleGloria(body, value) {
 
   if (!value) {
     _removeStorringtonPart(body, "GLORIA", pageTemplate, labelTemplate);
-    return;
   } else {
     page = "6";
     label = "";


### PR DESCRIPTION
- Gospel Acclamation has a special case for if it's Lent
  - Handler function includes unique `const` values pertaining to this, and the Google Docs template was edited as well
    - Google Docs template also needed to have some font size readjusted so as not to generate an additional blank page with the inclusion of Lenten Gospel Acclamation rules
- Removed unnecessary return statements in Gloria and Gospel Acclamation as templates should be overwritten by the time the handler functions reach "common" logic
- Started Gloria and Gospel if/else clauses with "None" cases for consistency moving forward