### PR TITLE
Storrington Mass Parts generation: Memorial Acclamation [FIX]

### DIFF
--- a/insertWeeklySchedule.js
+++ b/insertWeeklySchedule.js
@@ -131,6 +131,8 @@ function _handleGospel(body, value) {
   } else if (value === "2") {
     _insertStorringtonPart(body, pageTemplate, labelTemplate, "17", "");
     lenten = "Lenten ";
+  } else {
+    _insertStorringtonPart(body, pageTemplate, labelTemplate);
   }
 
   body.replaceText(lentenTemplate, lenten);


### PR DESCRIPTION
- Memorial Acclamation generation now uses helper functions to insert and remove the part if needed
- Changed switch/case clauses to if/else for more predictable behaviour
- Adherence to helper functions' standardized formatting should eliminate bugs from previous iteration
- Catch-all default (else) case will note values as invalid
- Gospel Acclamation also follows this behaviour