### PR TITLE
Push Google Sheets Fix

### DIFF
--- a/createMusicSchedule.js
+++ b/createMusicSchedule.js
@@ -16,7 +16,7 @@ function createMusicSchedule(entries) {
   for (let i = 0; i < numEntries; i++) {
     const entry = entries[i];
     copyMusicScheudleTemplate(doc);
-    insertWeeklySchedule(doc, entry);
+    insertEntrySchedule(doc, entry);
 
     if (i % 2 === 0) {
       // At the start of a new page, remove the extra paragraph whose index will have been saved from the previous iteration

--- a/createMusicSchedule.js
+++ b/createMusicSchedule.js
@@ -1,29 +1,29 @@
 /**
- * @param {Object[]} weeks
+ * @param {Object[]} entries
  * @returns String
  */
-function createMusicSchedule(weeks) {
+function createMusicSchedule(entries) {
   // The title of the new doc is the month of this year of the Sundays given
   // TODO: function that creates the document
-  const firstSundayofMonth = new Date(weeks[0].sunday);
-  const month = firstSundayofMonth.toLocaleString("en-CA", { month: "long" });
-  const year = firstSundayofMonth.getFullYear();
+  const firstEntryDay = new Date(entries[0].day);
+  const month = firstEntryDay.toLocaleString("en-CA", { month: "long" });
+  const year = firstEntryDay.getFullYear();
   const doc = DocumentApp.create(`Music Schedule - ${month} ${year}`);
 
   const body = doc.getBody();
 
-  const numWeeks = weeks.length;
-  for (let i = 0; i < numWeeks; i++) {
-    const week = weeks[i];
+  const numEntries = entries.length;
+  for (let i = 0; i < numEntries; i++) {
+    const entry = entries[i];
     copyMusicScheudleTemplate(doc);
-    insertWeeklySchedule(doc, week);
+    insertWeeklySchedule(doc, entry);
 
     if (i % 2 === 0) {
       // At the start of a new page, remove the extra paragraph whose index will have been saved from the previous iteration
-      // This needs to be after the next week's template has been appended
+      // This needs to be after the next entry's template has been appended
       if (i !== 0) body.removeChild(body.getChild(newParagraphChildIndex));
-      // Two weeks can fit on a page; put a rule between the two unless it's the last
-      if (i !== numWeeks - 1) body.appendHorizontalRule();
+      // Two entries can fit on a page; put a rule between the two unless it's the last
+      if (i !== numEntries - 1) body.appendHorizontalRule();
     }
 
     // The horizontal rule adds a paragraph; remove paragraph after the table

--- a/insertEntrySchedule.js
+++ b/insertEntrySchedule.js
@@ -1,8 +1,8 @@
-function insertWeeklySchedule(doc, week) {
+function insertEntrySchedule(doc, entry) {
   const body = doc.getBody();
 
   let [
-    sunday,
+    day,
     gathering,
     psalm,
     offertory,
@@ -12,19 +12,19 @@ function insertWeeklySchedule(doc, week) {
     line2,
     liturgicalDayTitle,
   ] = [
-    week.sunday,
-    week.gathering,
-    week.psalm,
-    week.offertory,
-    week.communion,
-    week.recessional,
-    week.gospelVerse.line1,
-    week.gospelVerse.line2,
-    week.liturgicalDayTitle,
+    entry.day,
+    entry.gathering,
+    entry.psalm,
+    entry.offertory,
+    entry.communion,
+    entry.recessional,
+    entry.gospelVerse.line1,
+    entry.gospelVerse.line2,
+    entry.liturgicalDayTitle,
   ];
 
   let hymns = [gathering, psalm, offertory, communion, recessional];
-  [
+  let [
     gatheringTitle,
     psalmTitle,
     offertoryTitle,
@@ -32,7 +32,7 @@ function insertWeeklySchedule(doc, week) {
     recessionalTitle,
   ] = hymns.map(_getHymnTitles);
 
-  body.replaceText("{date}", `${sunday} - ${liturgicalDayTitle}`);
+  body.replaceText("{date}", `${day} - ${liturgicalDayTitle}`);
   body.replaceText("{gathering-title}", gatheringTitle);
   body.replaceText("{psalm-title}", psalmTitle);
   body.replaceText("{offertory-title}", offertoryTitle);
@@ -55,7 +55,7 @@ function insertWeeklySchedule(doc, week) {
   body.replaceText("{communion-number}", communionNumber);
   body.replaceText("{recessional-number}", recessionalNumber);
 
-  const storringtonParts = week.storrington;
+  const storringtonParts = entry.storrington;
   storringtonParts.forEach((element) => {
     let name = element.name;
     let value = element.value;

--- a/processForm.js
+++ b/processForm.js
@@ -1,5 +1,5 @@
 function processForm(
-  sundays,
+  days,
   gatherings,
   psalms,
   offertories,
@@ -11,8 +11,8 @@ function processForm(
 ) {
   initializeData();
 
-  let weeks = processWeeks(
-    sundays,
+  let entries = processScheduleEntries(
+    days,
     gatherings,
     psalms,
     offertories,
@@ -23,7 +23,7 @@ function processForm(
     liturgicalDayTitles
   );
 
-  pushGoogleSheets(weeks);
-  const response = createMusicSchedule(weeks);
+  pushGoogleSheets(entries);
+  const response = createMusicSchedule(entries);
   return response;
 }

--- a/processScheduleEntries.js
+++ b/processScheduleEntries.js
@@ -1,6 +1,6 @@
 /**
- * Takes all information submitted from the form and returns them in chunks relevant to a particular week
- * @param {*} sundays
+ * Takes all information submitted from the form and returns them in chunks relevant to a particular entry
+ * @param {*} days
  * @param {*} gatherings
  * @param {*} psalms
  * @param {*} offertories
@@ -11,8 +11,8 @@
  * @param {*} liturgicalDayTitles
  * @returns {Object[]}
  */
-function processWeeks(
-  sundays,
+function processScheduleEntries(
+  days,
   gatherings,
   psalms,
   offertories,
@@ -22,18 +22,18 @@ function processWeeks(
   storringtonParts,
   liturgicalDayTitles
 ) {
-  let weeks = [];
+  let entries = [];
 
-  // For every Sunday, filter the Storrington parts for the relevant elements
-  const numSundays = sundays.length;
-  for (let i = 0; i < numSundays; i++) {
+  // For every day, filter the Storrington parts for the relevant elements
+  const numDays = days.length;
+  for (let i = 0; i < numDays; i++) {
     // storringtonParts is a list of all the parts for the month; {name, value}
     // name will include a substring at the end of the form "-i"
-    let thisWeekStorrington = storringtonParts.filter((el) =>
+    let thisEntryStorrington = storringtonParts.filter((el) =>
       el.name.endsWith(`-${i}`)
     );
     // once this week's parts have been filtered based on i value, strip this suffix for convenience
-    thisWeekStorrington = thisWeekStorrington.map((el) => {
+    thisEntryStorrington = thisEntryStorrington.map((el) => {
       // also strip the "thisMonth-" / "nextMonth-" prefix
       const start = 10;
       return {
@@ -55,27 +55,27 @@ function processWeeks(
     for (let i = 0; i < allStorringtonParts.length; i++) {
       const part = allStorringtonParts[i];
       // If it wasn't checked as an input, it wouldn't have been sent
-      if (!thisWeekStorrington.some((el) => el.name === part))
+      if (!thisEntryStorrington.some((el) => el.name === part))
         // So what we'll do is add an entry with the value false
-        thisWeekStorrington.splice(i, 0, { name: part, value: false });
+        thisEntryStorrington.splice(i, 0, { name: part, value: false });
     }
 
     // consolidate all information relevant to the week
     // frontend now submits data: "{Hymn Number} - {Hymn Name}" for Gather
     // Binder hymns unaffected
-    let week = {
-      sunday: sundays[i],
+    let entry = {
+      day: days[i],
       gathering: gatherings[i].split(" - ")[0],
       psalm: psalms[i].split(" - ")[0],
       offertory: offertories[i].split(" - ")[0],
       communion: communions[i].split(" - ")[0],
       recessional: recessionals[i].split(" - ")[0],
       gospelVerse: gospelVerses[i],
-      storrington: thisWeekStorrington,
-      liturgicalDayTitle: liturgicalDayTitles[i]
+      storrington: thisEntryStorrington,
+      liturgicalDayTitle: liturgicalDayTitles[i],
     };
-    weeks.push(week);
+    entries.push(entry);
   }
 
-  return weeks;
+  return entries;
 }

--- a/pushGoogleSheets.js
+++ b/pushGoogleSheets.js
@@ -32,9 +32,7 @@ function pushGoogleSheets(entries) {
       entry.liturgicalDayTitle,
     ];
 
-    Logger.log(day);
     const date = Utilities.formatDate(new Date(day), timeZone, "MM/dd/yyyy");
-    Logger.log(date);
 
     schedule.insertRowAfter(lastCell);
     lastCell++;

--- a/pushGoogleSheets.js
+++ b/pushGoogleSheets.js
@@ -1,14 +1,14 @@
 /**
- * @param {Object[]} weeks
+ * @param {Object[]} entries
  */
-function pushGoogleSheets(weeks) {
+function pushGoogleSheets(entries) {
   const schedule = GlobalConstants.schedule;
   const timeZone = GlobalConstants.timeZone;
 
   const columnAVals = schedule.getRange("A:A").getValues();
   let lastCell = columnAVals.length;
 
-  weeks.forEach((week) => {
+  entries.forEach((entry) => {
     // Extract info
     let [
       day,
@@ -21,28 +21,30 @@ function pushGoogleSheets(weeks) {
       line2,
       liturgicalDayTitle,
     ] = [
-      week.day,
-      week.gathering,
-      week.psalm,
-      week.offertory,
-      week.communion,
-      week.recessional,
-      week.gospelVerse.line1,
-      week.gospelVerse.line2,
-      week.liturgicalDayTitle,
+      entry.day,
+      entry.gathering,
+      entry.psalm,
+      entry.offertory,
+      entry.communion,
+      entry.recessional,
+      entry.gospelVerse.line1,
+      entry.gospelVerse.line2,
+      entry.liturgicalDayTitle,
     ];
 
+    Logger.log(day);
     const date = Utilities.formatDate(new Date(day), timeZone, "MM/dd/yyyy");
+    Logger.log(date);
 
     schedule.insertRowAfter(lastCell);
     lastCell++;
 
-    const weekRange = schedule.getRange(`A${lastCell}:O${lastCell}`);
+    const entryRange = schedule.getRange(`A${lastCell}:O${lastCell}`);
 
     // Hymns
     let rowData = [date, gathering, psalm, offertory, communion, recessional];
     // Storrington parts are input in order on the web form and kept in order on the Google Sheet
-    const storringtonValues = week.storrington.map((part) => part.value);
+    const storringtonValues = entry.storrington.map((part) => part.value);
     rowData = rowData.concat(storringtonValues);
     rowData.push(line1);
     rowData.push(line2);
@@ -52,6 +54,6 @@ function pushGoogleSheets(weeks) {
     let data = [];
     data.push(rowData);
 
-    weekRange.setValues(data);
+    entryRange.setValues(data);
   });
 }

--- a/pushGoogleSheets.js
+++ b/pushGoogleSheets.js
@@ -4,10 +4,14 @@
 function pushGoogleSheets(weeks) {
   const schedule = GlobalConstants.schedule;
   const timeZone = GlobalConstants.timeZone;
+
+  const columnAVals = schedule.getRange("A:A").getValues();
+  let lastCell = columnAVals.length;
+
   weeks.forEach((week) => {
     // Extract info
     let [
-      sunday,
+      day,
       gathering,
       psalm,
       offertory,
@@ -17,7 +21,7 @@ function pushGoogleSheets(weeks) {
       line2,
       liturgicalDayTitle,
     ] = [
-      week.sunday,
+      week.day,
       week.gathering,
       week.psalm,
       week.offertory,
@@ -28,21 +32,15 @@ function pushGoogleSheets(weeks) {
       week.liturgicalDayTitle,
     ];
 
-    const thisSunday = Utilities.formatDate(
-      new Date(sunday),
-      timeZone,
-      "MM/dd/yyyy"
-    );
-    const findThisSunday = schedule.createTextFinder(thisSunday);
-    const thisSundayRange = findThisSunday.findNext();
-    const thisSundayRowIndex = thisSundayRange.getRowIndex();
+    const date = Utilities.formatDate(new Date(day), timeZone, "MM/dd/yyyy");
 
-    const weekRange = schedule.getRange(
-      `B${thisSundayRowIndex}:O${thisSundayRowIndex}`
-    );
+    schedule.insertRowAfter(lastCell);
+    lastCell++;
+
+    const weekRange = schedule.getRange(`A${lastCell}:O${lastCell}`);
 
     // Hymns
-    let rowData = [gathering, psalm, offertory, communion, recessional];
+    let rowData = [date, gathering, psalm, offertory, communion, recessional];
     // Storrington parts are input in order on the web form and kept in order on the Google Sheet
     const storringtonValues = week.storrington.map((part) => part.value);
     rowData = rowData.concat(storringtonValues);


### PR DESCRIPTION
- Made pushing to Google Sheets more general with its language by replacing references to weeks and Sundays with "entries" and dates
- `createTextFinder` seemed to be causing issues, so I settled for inserting new rows
  - This will have to be revisited for when editing old schedules
  - In the process, removed unnecessary rows from other sheets in the overall document